### PR TITLE
Closes ExactTarget/node-fuel#7

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "lib/fuel",
   "dependencies": {
     "extend": "1.2.1",
-    "request": "~2.27.0"
+    "request": "~2.60.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
it seems to be passing all included tests with this version of request. I would recommend upgrading to it.